### PR TITLE
Dev 250710

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -1,5 +1,5 @@
 // c 2024-03-05
-// m 2025-07-07
+// m 2025-07-12
 
 uint[]        bestCpTimes;
 Json::Value@  bestEver        = Json::Object();
@@ -128,11 +128,7 @@ void Main() {
 void Render() {
     RenderDebug();
 
-    if (false
-        or !S_Enabled
-        or (S_HideWithGame and !UI::IsGameUIVisible())
-        or (S_HideWithOP and !UI::IsOverlayShown())
-    ) {
+    if (!S_Enabled) {
         return;
     }
 
@@ -207,6 +203,13 @@ void Render() {
 
         lastTime = theoreticalTime;
         SetBestEver(App.RootMap.EdChallengeId, theoreticalTime);
+    }
+
+    if (false
+        or (S_HideWithGame and !UI::IsGameUIVisible())
+        or (S_HideWithOP and !UI::IsOverlayShown())
+    ) {
+        return;
     }
 
     cpCount = raceData.LocalPlayer.cpCount;

--- a/src/UME.as
+++ b/src/UME.as
@@ -1,27 +1,41 @@
 // c 2025-07-06
-// m 2025-07-10
+// m 2025-07-12
 
 #if DEPENDENCY_ULTIMATEMEDALSEXTENDED
-
-UltimateMedalsExtended::Config@ configBest = UltimateMedalsExtended::Config();
 
 class UME_Best : UltimateMedalsExtended::IMedal {
     string uid;
 
     UltimateMedalsExtended::Config GetConfig() override {
-        configBest.defaultName = "Best Copium";
-        configBest.icon = "\\$777" + Icons::ArrowCircleUp;
-        configBest.shareIcon = false;
-        configBest.usePreviousColor = true;
+        UltimateMedalsExtended::Config c;
 
-        return configBest;
+        c.defaultName = "Best Copium";
+        c.icon = "\\$777" + Icons::ArrowCircleUp;
+        c.shareIcon = false;
+        c.usePreviousColor = true;
+
+        return c;
     }
 
     uint GetMedalTime() override {
+        if (false
+            or pluginMeta is null
+            or !pluginMeta.Enabled
+        ) {
+            return 0;
+        }
+
         return GetBestEver(uid);
     }
 
     bool HasMedalTime(const string&in uid) override {
+        if (false
+            or pluginMeta is null
+            or !pluginMeta.Enabled
+        ) {
+            return false;
+        }
+
         return GetBestEver(uid) > 0;
     }
 
@@ -32,21 +46,35 @@ class UME_Best : UltimateMedalsExtended::IMedal {
 
 class UME_Previous : UltimateMedalsExtended::IMedal {
     UltimateMedalsExtended::Config GetConfig() override {
-        UltimateMedalsExtended::Config config;
+        UltimateMedalsExtended::Config c;
 
-        config.defaultName = "Previous Copium";
-        config.icon = "\\$777" + Icons::ArrowCircleLeft;
-        config.shareIcon = false;
-        config.usePreviousColor = true;
+        c.defaultName = "Previous Copium";
+        c.icon = "\\$777" + Icons::ArrowCircleLeft;
+        c.shareIcon = false;
+        c.usePreviousColor = true;
 
-        return config;
+        return c;
     }
 
     uint GetMedalTime() override {
+        if (false
+            or pluginMeta is null
+            or !pluginMeta.Enabled
+        ) {
+            return 0;
+        }
+
         return lastTime;
     }
 
     bool HasMedalTime(const string&in uid) override {
+        if (false
+            or pluginMeta is null
+            or !pluginMeta.Enabled
+        ) {
+            return false;
+        }
+
         return lastTime > bestSessionTime;
     }
 
@@ -55,21 +83,35 @@ class UME_Previous : UltimateMedalsExtended::IMedal {
 
 class UME_Session : UltimateMedalsExtended::IMedal {
     UltimateMedalsExtended::Config GetConfig() override {
-        UltimateMedalsExtended::Config config;
+        UltimateMedalsExtended::Config c;
 
-        config.defaultName = "Session Copium";
-        config.icon = "\\$777" + Icons::ArrowCircleDown;
-        config.shareIcon = false;
-        config.usePreviousColor = true;
+        c.defaultName = "Session Copium";
+        c.icon = "\\$777" + Icons::ArrowCircleDown;
+        c.shareIcon = false;
+        c.usePreviousColor = true;
 
-        return config;
+        return c;
     }
 
     uint GetMedalTime() override {
+        if (false
+            or pluginMeta is null
+            or !pluginMeta.Enabled
+        ) {
+            return 0;
+        }
+
         return bestSessionTime;
     }
 
     bool HasMedalTime(const string&in uid) override {
+        if (false
+            or pluginMeta is null
+            or !pluginMeta.Enabled
+        ) {
+            return false;
+        }
+
         return bestSessionTime > GetBestEver(uid);
     }
 

--- a/src/UME.as
+++ b/src/UME.as
@@ -36,7 +36,11 @@ class UME_Best : UltimateMedalsExtended::IMedal {
             return false;
         }
 
-        return GetBestEver(uid) > 0;
+        const uint best = GetBestEver(uid);
+        return true
+            and best > 0
+            and best < GetPB()
+        ;
     }
 
     void UpdateMedal(const string&in uid) override {

--- a/src/UME.as
+++ b/src/UME.as
@@ -1,20 +1,20 @@
 // c 2025-07-06
-// m 2025-07-07
+// m 2025-07-10
 
 #if DEPENDENCY_ULTIMATEMEDALSEXTENDED
+
+UltimateMedalsExtended::Config@ configBest = UltimateMedalsExtended::Config();
 
 class UME_Best : UltimateMedalsExtended::IMedal {
     string uid;
 
     UltimateMedalsExtended::Config GetConfig() override {
-        UltimateMedalsExtended::Config config;
+        configBest.defaultName = "Best Copium";
+        configBest.icon = "\\$777" + Icons::ArrowCircleUp;
+        configBest.shareIcon = false;
+        configBest.usePreviousColor = true;
 
-        config.defaultName = "Best Copium";
-        config.icon = "\\$777" + Icons::ArrowCircleUp;
-        config.shareIcon = false;
-        config.usePreviousColor = true;
-
-        return config;
+        return configBest;
     }
 
     uint GetMedalTime() override {
@@ -33,10 +33,12 @@ class UME_Best : UltimateMedalsExtended::IMedal {
 class UME_Previous : UltimateMedalsExtended::IMedal {
     UltimateMedalsExtended::Config GetConfig() override {
         UltimateMedalsExtended::Config config;
+
         config.defaultName = "Previous Copium";
         config.icon = "\\$777" + Icons::ArrowCircleLeft;
         config.shareIcon = false;
         config.usePreviousColor = true;
+
         return config;
     }
 
@@ -52,17 +54,14 @@ class UME_Previous : UltimateMedalsExtended::IMedal {
 }
 
 class UME_Session : UltimateMedalsExtended::IMedal {
-    UltimateMedalsExtended::Config@ config;
+    UltimateMedalsExtended::Config GetConfig() override {
+        UltimateMedalsExtended::Config config;
 
-    UME_Session() {
-        @config = UltimateMedalsExtended::Config();
         config.defaultName = "Session Copium";
         config.icon = "\\$777" + Icons::ArrowCircleDown;
         config.shareIcon = false;
         config.usePreviousColor = true;
-    }
 
-    UltimateMedalsExtended::Config GetConfig() override {
         return config;
     }
 

--- a/src/Util.as
+++ b/src/Util.as
@@ -1,5 +1,5 @@
 // c 2024-03-05
-// m 2025-07-07
+// m 2025-07-12
 
 enum TimesSource {
     RaceData,
@@ -24,6 +24,31 @@ uint GetBestEver(const string&in uid) {
     }
 
     return uint(bestEver[uid]);
+}
+
+uint GetPB() {
+    auto App = cast<CTrackMania>(GetApp());
+
+    if (false
+        or App.RootMap is null
+        or App.MenuManager is null
+        or App.MenuManager.MenuCustom_CurrentManiaApp is null
+        or App.MenuManager.MenuCustom_CurrentManiaApp.ScoreMgr is null
+        or App.UserManagerScript is null
+        or App.UserManagerScript.Users.Length == 0
+        or App.UserManagerScript.Users[0] is null
+    ) {
+        return uint(-1);
+    }
+
+    return App.MenuManager.MenuCustom_CurrentManiaApp.ScoreMgr.Map_GetRecord_v2(
+        App.UserManagerScript.Users[0].Id,
+        App.RootMap.EdChallengeId,
+        "PersonalBest",
+        "",
+        "TimeAttack",
+        ""
+    );
 }
 
 vec4 GetMedalColor(const int medal) {


### PR DESCRIPTION
fixed:
- "best ever" time showing in UME when slower than PB
- UME times not updating when HUD is off