### PR TITLE
Bandaid fix for MLFeed

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -191,7 +191,11 @@ void Render() {
         ? raceData.LocalPlayer.LastTheoreticalCpTime
         : Math::Max(0, raceData.LocalPlayer.TheoreticalRaceTime)
     ;
-    if (int(theoreticalTime) <= 0) {
+    const uint raceTime = finished
+        ? raceData.LocalPlayer.lastCpTime
+        : raceData.LocalPlayer.CurrentRaceTime
+    ;
+    if (int(theoreticalTime) <= 0 || int(theoreticalTime) > int(raceTime) - 500) {
         return;
     }
 


### PR DESCRIPTION
Since MLFeed sometimes fails to update its data (see https://github.com/XertroV/tm-mlfeed-race-data/issues/6), causing issues like #21, a temporary fix is checking if the copium time is valid by comparing it to the race time. Any copium should be at least 1 second faster than the race time, since a respawn takes 1 second

The code checks for 500ms instead to avoid any issues if both timers are not 100% in sync